### PR TITLE
Bring up to date with ghcjs-0.2 and criterion 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ cabal-dev
 /doc-formulae/fft-formula.log
 /doc-formulae/ifft-formula.aux
 /doc-formulae/ifft-formula.log
+.cabal-sandbox
+cabal.sandbox.config

--- a/arb-fft.cabal
+++ b/arb-fft.cabal
@@ -47,12 +47,12 @@ Library
   ghc-prof-options: -auto-all -caf-all
   build-depends:    base                        >= 4.6      && < 5,
                     containers                  >= 0.5.0.0  && < 0.6,
-                    criterion                   >= 0.8.0.0  && < 0.9,
+                    criterion                   >= 1.1      && < 1.2,
                     directory                   >= 1.2.0.1  && < 1.3,
-                    filepath                    >= 1.3.0.1  && < 1.4,
-                    primitive                   >= 0.5.1.0  && < 0.6,
-                    transformers                >= 0.3.0.0  && < 0.4,
-                    vector                      >= 0.10.9.1 && < 0.11
+                    filepath                    >= 1.3.0.1  && < 1.5,
+                    primitive                   >= 0.5.1.0  && < 0.7,
+                    transformers                >= 0.3.0.0  && < 0.5,
+                    vector                      >= 0.10.9.1 && < 0.12
   default-language: Haskell2010
   if flag(LLVM)
     ghc-options:    -O2 -fllvm
@@ -66,8 +66,8 @@ Test-Suite basic-test
   build-depends:    arb-fft,
                     base                        >= 4.6      && < 5,
                     containers                  >= 0.5.0.0  && < 0.6,
-                    vector                      >= 0.10.9.1 && < 0.11,
-                    QuickCheck                  >= 2.6      && < 2.7,
+                    vector                      >= 0.10.9.1 && < 0.12,
+                    QuickCheck                  >= 2.8      && < 2.9,
                     tasty                       >= 0.3,
                     tasty-quickcheck            >= 0.3
   default-language: Haskell2010
@@ -78,6 +78,6 @@ Executable profile-256
   build-depends:    arb-fft,
                     base                        >= 4.6      && < 5,
                     containers                  >= 0.5.0.0  && < 0.6,
-                    vector                      >= 0.10.9.1 && < 0.11,
+                    vector                      >= 0.10.9.1 && < 0.12,
                     criterion
   default-language: Haskell2010

--- a/arb-fft.cabal
+++ b/arb-fft.cabal
@@ -1,5 +1,5 @@
 name:               arb-fft
-version:            0.2.0.2
+version:            0.3.0.0
 synopsis:           Pure Haskell arbitrary length FFT library
 homepage:           https://github.com/ian-ross/arb-fft
 license:            BSD3

--- a/test/basic-test.hs
+++ b/test/basic-test.hs
@@ -4,8 +4,8 @@ module Main where
 import Prelude hiding ((++), length, map, maximum, sum, zipWith)
 import qualified Prelude as P
 import Test.Tasty
-import Test.Tasty.QuickCheck
-import Test.QuickCheck
+import Test.Tasty.QuickCheck hiding (generate)
+import Test.QuickCheck hiding (generate)
 import Test.QuickCheck.Monadic
 import Control.Applicative ((<$>))
 import Data.Complex

--- a/test/profile-256.hs
+++ b/test/profile-256.hs
@@ -1,6 +1,8 @@
 module Main where
 
-import Criterion.Main
+import Criterion
+import Criterion.Main.Options
+import Criterion.Types
 import Data.Complex
 import Data.Vector
 import qualified Numeric.FFT as FFT
@@ -12,4 +14,5 @@ tstvec sz = generate sz (\i -> let ii = fromIntegral i
 main :: IO ()
 main = do
   p <- FFT.plan 256
-  run (nf (FFT.fftWith p) (tstvec 256)) 1000
+  benchmarkWith (defaultConfig { resamples = 1000 }) 
+    (nf (FFT.fftWith p) (tstvec 256))


### PR DESCRIPTION
These changes allow arb-fft to compile and tests to pass under ghc 7.10.2 and all the dependency constraints coming along with ghcjs.

The changes to Numeric.FFT.Plan might change the way criterion operates - criterion >= 1.0 dropped some types like `Environment` without a clear replacement, so the caching of environment measurement became impossible, and that measurement code was removed. Is this Ok?