### PR TITLE
Drop criterion for criterion-measurement in library

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+HEAD
+-------
+* Remove criterion dependency from the library
+
 0.3.0.1
 -------
 * Updates for cabal 2.4 including relaxation of upper limits and some hlinting

--- a/Numeric/FFT/Plan.hs
+++ b/Numeric/FFT/Plan.hs
@@ -2,8 +2,8 @@ module Numeric.FFT.Plan ( plan, planFromFactors ) where
 
 import qualified Control.Monad          as CM
 import           Control.Monad.IO.Class
-import           Criterion.Measurement  (measure)
-import           Criterion.Types        hiding (measure)
+import           Criterion.Measurement              (measure)
+import           Criterion.Measurement.Types hiding (measure)
 import           Data.Complex
 import           Data.Function          (on)
 import qualified Data.IntMap.Strict     as IM

--- a/arb-fft.cabal
+++ b/arb-fft.cabal
@@ -50,8 +50,7 @@ Library
   ghc-prof-options: -auto-all -caf-all
   build-depends:    base                        >= 4.6,
                     containers                  >= 0.5.0.0,
-                    criterion                   >= 1.1,
-                    criterion-measurement,
+                    criterion-measurement       >= 0.1.1.0,
                     directory                   >= 1.2.0.1,
                     filepath                    >= 1.3.0.1,
                     primitive                   >= 0.5.1.0,


### PR DESCRIPTION
It turns out that everything needed by the library is available in `criterion-measurement` (at least as of `criterion-measurement-0.1.1.0`)